### PR TITLE
Swift 5.0 compatibility

### DIFF
--- a/CommonCrypto/module.modulemap
+++ b/CommonCrypto/module.modulemap
@@ -1,4 +1,0 @@
-module CommonCrypto [system] {
-    header "shim.h"
-    export *
-}

--- a/CommonCrypto/shim.h
+++ b/CommonCrypto/shim.h
@@ -1,1 +1,0 @@
-#include <CommonCrypto/CommonCrypto.h>

--- a/JWT.xcodeproj/project.pbxproj
+++ b/JWT.xcodeproj/project.pbxproj
@@ -99,9 +99,9 @@
 
 /* Begin PBXFileReference section */
 		"JWT::JWA::Product" /* JWA.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = JWA.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"JWT::JWATests::Product" /* JWATests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = JWATests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		"JWT::JWATests::Product" /* JWATests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = JWATests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		"JWT::JWT::Product" /* JWT.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = JWT.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"JWT::JWTTests::Product" /* JWTTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = JWTTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		"JWT::JWTTests::Product" /* JWTTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = JWTTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		OBJ_10 /* Base64.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base64.swift; sourceTree = "<group>"; };
 		OBJ_11 /* ClaimSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaimSet.swift; sourceTree = "<group>"; };
 		OBJ_12 /* Claims.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Claims.swift; sourceTree = "<group>"; };
@@ -366,6 +366,20 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 9999;
+				TargetAttributes = {
+					"JWT::JWA" = {
+						LastSwiftMigration = 1020;
+					};
+					"JWT::JWATests" = {
+						LastSwiftMigration = 1020;
+					};
+					"JWT::JWT" = {
+						LastSwiftMigration = 1020;
+					};
+					"JWT::JWTTests" = {
+						LastSwiftMigration = 1020;
+					};
+				};
 			};
 			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "JWT" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -505,6 +519,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
 				SWIFT_INCLUDE_PATHS = CommonCrypto;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				USE_HEADERMAP = NO;
 			};
 			name = Debug;
@@ -526,6 +541,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
 				SWIFT_INCLUDE_PATHS = CommonCrypto;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
 				USE_HEADERMAP = NO;
 			};
 			name = Release;
@@ -551,7 +567,7 @@
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = JWA;
 			};
 			name = Debug;
@@ -577,7 +593,7 @@
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = JWA;
 			};
 			name = Release;
@@ -599,7 +615,7 @@
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = JWATests;
 			};
 			name = Debug;
@@ -621,7 +637,7 @@
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = JWATests;
 			};
 			name = Release;
@@ -647,7 +663,7 @@
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = JWT;
 			};
 			name = Debug;
@@ -673,7 +689,7 @@
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = JWT;
 			};
 			name = Release;
@@ -683,7 +699,7 @@
 			buildSettings = {
 				LD = /usr/bin/true;
 				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -692,7 +708,7 @@
 			buildSettings = {
 				LD = /usr/bin/true;
 				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -725,7 +741,7 @@
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = JWTTests;
 			};
 			name = Debug;
@@ -747,7 +763,7 @@
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = JWTTests;
 			};
 			name = Release;

--- a/JWT.xcodeproj/project.pbxproj
+++ b/JWT.xcodeproj/project.pbxproj
@@ -124,7 +124,6 @@
 		OBJ_33 /* PayloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayloadTests.swift; sourceTree = "<group>"; };
 		OBJ_35 /* HMACTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HMACTests.swift; sourceTree = "<group>"; };
 		OBJ_36 /* NoneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoneTests.swift; sourceTree = "<group>"; };
-		OBJ_37 /* CommonCrypto */ = {isa = PBXFileReference; lastKnownFileType = folder; path = CommonCrypto; sourceTree = SOURCE_ROOT; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		OBJ_9 /* Algorithm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Algorithm.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -243,7 +242,6 @@
 				OBJ_6 /* Package.swift */,
 				OBJ_7 /* Sources */,
 				OBJ_25 /* Tests */,
-				OBJ_37 /* CommonCrypto */,
 				OBJ_38 /* Dependencies */,
 				OBJ_39 /* Products */,
 			);
@@ -374,6 +372,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = OBJ_5;

--- a/Sources/JWA/HMAC/HMACCommonCrypto.swift
+++ b/Sources/JWA/HMAC/HMACCommonCrypto.swift
@@ -5,7 +5,7 @@ import CommonCrypto
 extension HMACAlgorithm: SignAlgorithm, VerifyAlgorithm {
   public func sign(_ message: Data) -> Data {
     let context = UnsafeMutablePointer<CCHmacContext>.allocate(capacity: 1)
-    defer { context.deallocate(capacity: 1) }
+    defer { context.deallocate() }
 
     key.withUnsafeBytes() { (buffer: UnsafePointer<UInt8>) in
       CCHmacInit(context, hash.commonCryptoAlgorithm, buffer, size_t(key.count))

--- a/Sources/JWA/HMAC/HMACCommonCrypto.swift
+++ b/Sources/JWA/HMAC/HMACCommonCrypto.swift
@@ -7,12 +7,14 @@ extension HMACAlgorithm: SignAlgorithm, VerifyAlgorithm {
     let context = UnsafeMutablePointer<CCHmacContext>.allocate(capacity: 1)
     defer { context.deallocate() }
 
-    key.withUnsafeBytes() { (buffer: UnsafePointer<UInt8>) in
-      CCHmacInit(context, hash.commonCryptoAlgorithm, buffer, size_t(key.count))
+    key.withUnsafeBytes { ptr in
+        let buffer = ptr.baseAddress?.assumingMemoryBound(to: UInt8.self)
+        CCHmacInit(context, hash.commonCryptoAlgorithm, buffer, size_t(key.count))
     }
 
-    message.withUnsafeBytes { (buffer: UnsafePointer<UInt8>) in
-      CCHmacUpdate(context, buffer, size_t(message.count))
+    message.withUnsafeBytes { ptr in
+        let buffer = ptr.baseAddress?.assumingMemoryBound(to: UInt8.self)
+        CCHmacUpdate(context, buffer, size_t(message.count))
     }
 
     var hmac = Array<UInt8>(repeating: 0, count: Int(hash.commonCryptoDigestLength))

--- a/Tests/JWTTests/JWTEncodeTests.swift
+++ b/Tests/JWTTests/JWTEncodeTests.swift
@@ -24,13 +24,19 @@ class JWTEncodeTests: XCTestCase {
       builder.issuer = "fuller.li"
     }
 
-    XCTAssertEqual(jwt, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJmdWxsZXIubGkifQ.d7B7PAQcz1E6oNhrlxmHxHXHgg39_k7X7wWeahl8kSQ")
+    XCTAssert(jwt == "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJmdWxsZXIubGkifQ.d7B7PAQcz1E6oNhrlxmHxHXHgg39_k7X7wWeahl8kSQ"
+        || jwt == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJmdWxsZXIubGkifQ.x5Fdll-kZBImOPtpT1fZH_8hDW01Ax3pbZx_EiljoLk")
   }
 
   func testEncodingClaimsWithHeaders() {
     let algorithm = Algorithm.hs256("secret".data(using: .utf8)!)
     let jwt = JWT.encode(claims: ClaimSet(), algorithm: algorithm, headers: ["kid": "x"])
 
-    XCTAssertEqual(jwt, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IngifQ.e30.ddEotxYYMMdat5HPgYFQnkHRdPXsxPG71ooyhIUoqGA")
+    XCTAssert(jwt == "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IngifQ.e30.ddEotxYYMMdat5HPgYFQnkHRdPXsxPG71ooyhIUoqGA"
+        || jwt == "eyJraWQiOiJ4IiwiYWxnIjoiSFMyNTYiLCJ0eXAiOiJKV1QifQ.e30.5KqN7N5a7Cfbe2eKN41FJIfgMjcdSZ7Nt16xqlyOeMo"
+        || jwt == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6IngifQ.e30.5t6a61tpSXFo5QBHYCnKAz2mTHrW9kaQ9n_b7e-jWw0"
+        || jwt == "eyJhbGciOiJIUzI1NiIsImtpZCI6IngiLCJ0eXAiOiJKV1QifQ.e30.xiT6fWe5dWGeuq8zFb0je_14Maa_9mHbVPSyJhUIJ54"
+        || jwt == "eyJ0eXAiOiJKV1QiLCJraWQiOiJ4IiwiYWxnIjoiSFMyNTYifQ.e30.DG5nmV2CVH6mV_iEm0xXZvL0DUJ22ek2xy6fNi_pGLc"
+        || jwt == "eyJraWQiOiJ4IiwidHlwIjoiSldUIiwiYWxnIjoiSFMyNTYifQ.e30.h5ZvlqECBIvu9uocR5_5uF3wnhga8vTruvXpzaHpRdA")
   }
 }


### PR DESCRIPTION
- Adds Swift 5.0 compatibility (via Xcode 10.2)
- Migrates project file to use recommended settings.
    - Including migrating the Localisation settings away from deprecated values.
- Removes method deprecation warnings where appropriate.
- Refactors unit tests based on `Dictionary` hash seed changes in Swift 5.0.
- Removes a redundant custom CommonCrypto modulemap.